### PR TITLE
Add badge for android-gems.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Android Gems](http://www.android-gems.com/badge/krimin-killr21/MaterialScrollBar.svg?branch=master)](http://www.android-gems.com/lib/krimin-killr21/MaterialScrollBar)
+
 # MaterialScrollBar
 
 An Android library that brings the Material Design 5.1 scrollbar to pre-5.1 devices. Designed for recyclerViews.


### PR DESCRIPTION
Added badge for android-gems: http://www.android-gems.com/lib/krimin-killr21/MaterialScrollBar , it looks like this:

[![Android Gems](http://www.android-gems.com/badge/krimin-killr21/MaterialScrollBar.svg?branch=master)](http://www.android-gems.com/lib/krimin-killr21/MaterialScrollBar)
