### PR TITLE
fixed crash on setting custom thickness

### DIFF
--- a/app/src/main/res/layout/activity_others.xml
+++ b/app/src/main/res/layout/activity_others.xml
@@ -15,24 +15,25 @@
   -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context=".MainActivity">
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:context=".MainActivity">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"/>
 
     <com.turingtechnologies.materialscrollbar.TouchScrollBar
-        app:msb_lightOnTouch="false"
-        app:msb_recyclerView="@id/recyclerView"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true"
         android:id="@+id/touchScrollBar"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        app:msb_barThickness="@dimen/scrollbar_thickness"
+        app:msb_lightOnTouch="false"
+        app:msb_recyclerView="@id/recyclerView"/>
 
 </RelativeLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="scrollbar_thickness">8dp</dimen>
 </resources>

--- a/lib/src/main/java/com/turingtechnologies/materialscrollbar/DragScrollBar.java
+++ b/lib/src/main/java/com/turingtechnologies/materialscrollbar/DragScrollBar.java
@@ -17,7 +17,6 @@
 package com.turingtechnologies.materialscrollbar;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
@@ -65,7 +64,7 @@ public class DragScrollBar extends MaterialScrollBar<DragScrollBar>{
                 if ((event.getAction() == MotionEvent.ACTION_MOVE || event.getAction() == MotionEvent.ACTION_DOWN) && held) {
                     onDown(event);
                     fadeIn();
-                //On Up
+                    //On Up
                 } else {
                     onUp();
 
@@ -100,7 +99,7 @@ public class DragScrollBar extends MaterialScrollBar<DragScrollBar>{
     }
 
     @Override
-    void implementFlavourPreferences(TypedArray a) {}
+    void implementFlavourPreferences() {}
 
     @Override
     float getHandleOffset(){

--- a/lib/src/main/java/com/turingtechnologies/materialscrollbar/MaterialScrollBar.java
+++ b/lib/src/main/java/com/turingtechnologies/materialscrollbar/MaterialScrollBar.java
@@ -231,7 +231,7 @@ public abstract class MaterialScrollBar<T> extends RelativeLayout {
 
         implementPreferences();
 
-        implementFlavourPreferences(a);
+        implementFlavourPreferences();
 
         a.recycle();
 
@@ -358,7 +358,7 @@ public abstract class MaterialScrollBar<T> extends RelativeLayout {
 
     abstract boolean getHide();
 
-    abstract void implementFlavourPreferences(TypedArray a);
+    abstract void implementFlavourPreferences();
 
     abstract float getHandleOffset();
 
@@ -566,8 +566,8 @@ public abstract class MaterialScrollBar<T> extends RelativeLayout {
         } else {
             removeOnLayoutChangeListener(indicatorLayoutListener);
             indicatorLayoutListener = (a,b,c,d,e,f,g,h,i) -> {
-                    setupIndicator(indicator, addSpaceSide);
-                    MaterialScrollBar.this.removeOnLayoutChangeListener(indicatorLayoutListener);
+                setupIndicator(indicator, addSpaceSide);
+                MaterialScrollBar.this.removeOnLayoutChangeListener(indicatorLayoutListener);
             };
             addOnLayoutChangeListener(indicatorLayoutListener);
         }

--- a/lib/src/main/java/com/turingtechnologies/materialscrollbar/TouchScrollBar.java
+++ b/lib/src/main/java/com/turingtechnologies/materialscrollbar/TouchScrollBar.java
@@ -26,30 +26,38 @@ import android.view.MotionEvent;
 import android.view.animation.Animation;
 import android.view.animation.TranslateAnimation;
 
-public class TouchScrollBar extends MaterialScrollBar<TouchScrollBar>{
+public class TouchScrollBar extends MaterialScrollBar<TouchScrollBar> {
 
     private boolean hide = true;
     private int hideDuration = 2500;
     private Handler uiHandler = new Handler(Looper.getMainLooper());
     private boolean respondToTouch = true;
+    private TypedArray flavourAttributes;
 
     private Runnable fadeBar = this::fadeOut;
 
-    public TouchScrollBar(Context context, AttributeSet attributeSet){
+    public TouchScrollBar(Context context, AttributeSet attributeSet) {
         super(context, attributeSet);
     }
 
-    public TouchScrollBar(Context context, AttributeSet attributeSet, int defStyle){
+    public TouchScrollBar(Context context, AttributeSet attributeSet, int defStyle) {
         super(context, attributeSet, defStyle);
     }
 
-    public TouchScrollBar(Context context, RecyclerView recyclerView, boolean lightOnTouch){
+    public TouchScrollBar(Context context, RecyclerView recyclerView, boolean lightOnTouch) {
         super(context, recyclerView, lightOnTouch);
     }
 
-    public TouchScrollBar setHideDuration(int duration){
+    public TouchScrollBar setHideDuration(int duration) {
         hideDuration = duration;
         return this;
+    }
+
+    @Override
+    void setUpProps(Context context, AttributeSet attributes) {
+        super.setUpProps(context, attributes);
+        flavourAttributes = context.getTheme().obtainStyledAttributes(
+                attributes, R.styleable.TouchScrollBar, 0, 0);
     }
 
     @Override
@@ -67,16 +75,16 @@ public class TouchScrollBar extends MaterialScrollBar<TouchScrollBar>{
                 //On Down
                 if (event.getAction() != MotionEvent.ACTION_UP) {
 
-                    if(!hidden || respondToTouch){
+                    if (!hidden || respondToTouch) {
                         onDown(event);
 
-                        if(hide){
+                        if (hide) {
                             uiHandler.removeCallbacks(fadeBar);
                             fadeIn();
                         }
                     }
 
-                //On Up
+                    //On Up
                 } else {
 
                     onUp();
@@ -105,7 +113,7 @@ public class TouchScrollBar extends MaterialScrollBar<TouchScrollBar>{
 
     @Override
     void onScroll() {
-        if(hide){
+        if (hide) {
             uiHandler.removeCallbacks(fadeBar);
             uiHandler.postDelayed(fadeBar, hideDuration);
             fadeIn();
@@ -119,22 +127,22 @@ public class TouchScrollBar extends MaterialScrollBar<TouchScrollBar>{
     }
 
     @Override
-    void implementFlavourPreferences(TypedArray a) {
-        if(a.hasValue(R.styleable.TouchScrollBar_msb_autoHide)){
-            setAutoHide(a.getBoolean(R.styleable.TouchScrollBar_msb_autoHide, true));
+    void implementFlavourPreferences() {
+        if (flavourAttributes.hasValue(R.styleable.TouchScrollBar_msb_autoHide)) {
+            setAutoHide(flavourAttributes.getBoolean(R.styleable.TouchScrollBar_msb_autoHide, true));
         }
-        if(a.hasValue(R.styleable.TouchScrollBar_msb_hideDelayInMilliseconds)){
-            hideDuration = (a.getInteger(R.styleable.TouchScrollBar_msb_hideDelayInMilliseconds, 2500));
+        if (flavourAttributes.hasValue(R.styleable.TouchScrollBar_msb_hideDelayInMilliseconds)) {
+            hideDuration = (flavourAttributes.getInteger(R.styleable.TouchScrollBar_msb_hideDelayInMilliseconds, 2500));
         }
     }
 
     @Override
-    float getHandleOffset(){
+    float getHandleOffset() {
         return 0;
     }
 
     @Override
-    float getIndicatorOffset(){
+    float getIndicatorOffset() {
         return 0;
     }
 
@@ -143,10 +151,10 @@ public class TouchScrollBar extends MaterialScrollBar<TouchScrollBar>{
      * should hide after a period of inactivity or not.
      * @param hide sets whether the bar should hide or not.
      *
-     * This method is experimental
+     *             This method is experimental
      */
-    public TouchScrollBar setAutoHide(Boolean hide){
-        if(!hide){
+    public TouchScrollBar setAutoHide(Boolean hide) {
+        if (!hide) {
             TranslateAnimation anim = new TranslateAnimation(Animation.RELATIVE_TO_PARENT, 0.0f,
                     Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_PARENT, 0.0f, Animation.RELATIVE_TO_PARENT, 0.0f);
             anim.setFillAfter(true);
@@ -162,7 +170,7 @@ public class TouchScrollBar extends MaterialScrollBar<TouchScrollBar>{
     /**
      * @param respondToTouchIfHidden Should the bar pop out and scroll if it is hidden?
      */
-    public TouchScrollBar setRespondToTouchIfHidden(boolean respondToTouchIfHidden){
+    public TouchScrollBar setRespondToTouchIfHidden(boolean respondToTouchIfHidden) {
         respondToTouch = respondToTouchIfHidden;
         return this;
     }


### PR DESCRIPTION
After setting custom thickness on TouchScrollBar app:msb_barThickness="8dp", the app crash.
This is due to incorrect typed array usage in child class. Here is a fix :)